### PR TITLE
hotfix CollectConsResulst chrom equals goi

### DIFF
--- a/RIssmed/CollectConsResults.py
+++ b/RIssmed/CollectConsResults.py
@@ -113,7 +113,7 @@ def screen_genes(
     border,
     ulim,
     procs,
-    roi,
+    unconstraint,
     outdir,
     dir,
     genes,
@@ -153,7 +153,7 @@ def screen_genes(
             # get files with specified pattern
             raw = os.path.abspath(
                 os.path.join(
-                    dir, goi, goi + "*_raw_*" + str(window) + "_" + str(span) + ".npy"
+                    dir, goi, goi + f"*_{unconstraint}_*" + str(window) + "_" + str(span) + ".npy"
                 )
             )
             unpaired = os.path.abspath(
@@ -646,7 +646,7 @@ def main():
             args.border,
             args.ulimit,
             args.procs,
-            args.roi,
+            args.unconstraint,
             args.outdir,
             args.dir,
             args.genes,

--- a/RIssmed/Tweaks/RIssmedArgparsers.py
+++ b/RIssmed/Tweaks/RIssmedArgparsers.py
@@ -247,7 +247,7 @@ def parseargs_collectpl():
         "-p",
         "--pattern",
         type=str,
-        default="250,150",
+        default="240,60",
         help="Pattern for files and window, e.g. Seq1_30,250",
     )
     parser.add_argument(
@@ -277,10 +277,10 @@ def parseargs_collectpl():
     )
     parser.add_argument(
         "-r",
-        "--roi",
+        "--unconstraint",
         type=str,
-        default=None,
-        help="Define Region of Interest that will be compared",
+        default="raw",
+        help="same name as unconstraint provided at ConstraintPLFold -r",
     )
     parser.add_argument(
         "-o", "--outdir", type=str, default="", help="Directory to write to"


### PR DESCRIPTION
only replaces first occurrence of goi with with StruCons to find constraint npy files. Prevents not finding files if chromosome name is equal to the goi name. 